### PR TITLE
docs: update tryLegacySyncExport docstring to match behavior

### DIFF
--- a/src/utils/markdownlint-loader.ts
+++ b/src/utils/markdownlint-loader.ts
@@ -62,7 +62,7 @@ async function tryImportPromiseSubpath(
 
 /**
  * Check for legacy sync export on the given module candidate.
- * Returns true and logs if found, incrementing fallback counter if needed.
+ * Returns true and logs if found (does not increment fallback counter).
  */
 function tryLegacySyncExport(candidate: unknown, _errors: string[]): boolean {
   if (candidate && typeof (candidate as Record<string, unknown>).sync === 'function') {


### PR DESCRIPTION
As discussed in #21, I have implemented Option A. This PR updates the docstring for the tryLegacySyncExport function to accurately reflect that it does not increment the fallback counter, aligning the documentation with the current implementation.

Closes #21